### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Compatibility
 
 Not supported:
 
-* `CBAutostalk.js` & `CBAutoedit.js` - These were used to emit messages into IRC, but haven't been used since 2018 (
-  80cab4)
-* `oftenvandalized.txt` - This was used to emit messages into IRC, but hasn't been used since, but haven't been used
+* `CBAutostalk.js` & `CBAutoedit.js` - These were used to emit messages into IRC, but haven't been used since 2018
+  (80cab4)
+* `oftenvandalized.txt` - This was used to emit messages into IRC, but hasn't been used
   since 2018 (80cab4)
 * `irc.wikimedia.org` - In favour of the HTTP event stream (which backs the IRC relay)
 * `titles.txt` - This is replaced by a MySQL table


### PR DESCRIPTION
* Duplicate sentence fragment.
* Spurious space before paren.